### PR TITLE
U/cuza/using-full-image-name

### DIFF
--- a/pkg/apis/config/defaults/image.go
+++ b/pkg/apis/config/defaults/image.go
@@ -18,4 +18,4 @@ limitations under the License.
 package defaults
 
 // Image is the default for the Config.Image field, aka the default node image.
-const Image = "kindest/node:v1.21.14@sha256:03ec1b55e8d197f2766fa908725d89d952272be56b8a39b41e4f423e9180ead8"
+const Image = "docker.io/kindest/node:v1.21.14@sha256:03ec1b55e8d197f2766fa908725d89d952272be56b8a39b41e4f423e9180ead8"


### PR DESCRIPTION
Using full image name to enable out of the box compatibility with podman and similars